### PR TITLE
Overhaul travel pipeline + fix state/dialogue/event-system bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 
 Potion Wars is a TypeScript + Ink CLI. Source lives in `src/`: entry `cli.tsx`, UI `ui/`, screen flows `screens/`, and Zustand store in `store/appStore.ts`. Core mechanics live in `core/` (combat, events, game, persistence, reputation, npcs, rivals, dialogue) with shared definitions in `types/`. Tests sit in `src/tests` (unit, integration, snapshots); mirror that layout. Compiled output goes to `dist/`—keep it generated-only.
 
-**Documentation**: Project docs live in `docs/` (primer, persistence, testing, roadmap) and `.kiro/steering/` (product, structure, tech). See `CLAUDE.md` for architecture details and `docs/primer.md` for system design. Historical architecture decisions archived in `docs/archive/`.
+**Documentation**: Project docs live in `docs/` (primer, persistence, testing) and `.kiro/steering/` (product, structure, tech). See `CLAUDE.md` for architecture details and `docs/primer.md` for system design. Historical architecture decisions archived in `docs/archive/`.
 
 ## Build, Test, and Development Commands
 
@@ -33,7 +33,6 @@ Ship via `yarn release` (release-it). Select semantic version bumps that match p
 - `docs/primer.md` - Game mechanics, system design, and architecture evolution
 - `docs/persistence.md` - Save system design and migration strategies
 - `docs/testing.md` - Testing scenarios and patterns with AVA + ink-testing-library
-- `docs/roadmap.md` - Feature roadmap and pre-release cleanup tasks
 
 **Steering Documents** (`.kiro/steering/`):
 - `product.md` - Core gameplay mechanics and target experience

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,7 +116,7 @@ brewPotion('Wisdom Draught', 5)
 - A known timing issue requires calling `get()` before `set()` to "warm up" the store in certain actions
 - See `src/store/appStore.ts:574-580` for detailed comments and TODO markers
 - This ensures `getState()` returns current values immediately after `set()` completes
-- Documented in `prompts/roadmap.md` under "Pre-Release Cleanup"
+- Documented in the store source comments
 
 ### Directory Structure
 
@@ -131,8 +131,8 @@ src/
 │   ├── common/                # Generic components (animations, inputs)
 │   └── game/                  # Game-specific components (status, prices, etc)
 ├── core/                      # Game logic (no UI)
-│   ├── state/                 # Legacy state utilities (selectors still used)
-│   ├── game/                  # Core mechanics (economy, travel, brewing)
+│   ├── state/                 # Message selectors and test utilities
+│   ├── game/                  # Core mechanics (economy, travel)
 │   ├── combat/                # Combat system
 │   ├── events/                # Random event system
 │   ├── npcs/                  # NPC management and interactions
@@ -147,7 +147,7 @@ src/
 
 ### Key Systems
 
-**State Management**: All state is managed in the Zustand store at `src/store/appStore.ts`. State updates are synchronous and happen via direct method calls (e.g., `brewPotion()`, `chooseEvent()`, `completeTravel()`). Components access state via `useStore()` with selector functions to prevent unnecessary re-renders. Legacy selectors from `src/core/state/selectors/` are still used for derived state calculations.
+**State Management**: All state is managed in the Zustand store at `src/store/appStore.ts`. State updates are synchronous and happen via direct method calls (e.g., `brewPotion()`, `chooseEvent()`, `completeTravel()`). Components access state via `useStore()` with selector functions to prevent unnecessary re-renders. Message selectors in `src/core/state/selectors/messageSelectors.ts` are used for derived message display calculations.
 
 **Game Actions**: The Zustand store provides direct action methods: `brewPotion()`, `sellPotion()`, `startTravel()`, `completeTravel()`, `triggerEvent()`, `chooseEvent()`, `acknowledgeEvent()`, `startNPCInteraction()`, `updateReputation()`, and more. All actions update state synchronously using Immer middleware for immutable updates.
 
@@ -194,7 +194,7 @@ Screen rendering is determined by state in the Zustand store (`ui.activeScreen`,
 
 ## Code Style
 
-- **Runtime**: Node.js 16+ with ES Modules
+- **Runtime**: Node.js 20+ with ES Modules
 - **Formatting**: Prettier (2-space indent, no semicolons, single quotes, LF line endings)
 - **Linting**: XO with React config
 - **Naming**: PascalCase for components, camelCase for functions/hooks/files, UPPER_CASE for constants
@@ -212,7 +212,7 @@ Screen rendering is determined by state in the Zustand store (`ui.activeScreen`,
 - **Snapshots**: Review diffs carefully, use `yarn test:fix` to update
 - **Test Utilities**: Use TestWrapper, renderWithContext, screenInteractions helpers
 
-See `prompts/testing.md` for detailed testing scenarios.
+See `docs/testing.md` for detailed testing scenarios.
 
 ## Important Development Patterns
 
@@ -259,7 +259,7 @@ When adding new actions to the Zustand store:
 
 **Constants**: Game data like potions and locations lives in `src/constants.ts`. This includes potion definitions (name, min/max price) and location data (name, description, danger level).
 
-**Build Output**: Entry point is `dist/cli.js` as executable binary. Module system is ES Modules with Node16 resolution, targeting ES2020 for Node.js 14+ compatibility.
+**Build Output**: Entry point is `dist/cli.js` as executable binary. Module system is ES Modules with Node16 resolution, targeting ES2022 for Node.js 20+ compatibility.
 
 **Weather System**: Impacts events and prices. Defined in `src/types/weather.types.ts`.
 
@@ -325,10 +325,9 @@ cat ~/.config/potion-wars/slot_N_save.json | jq '.day, .cash, .debt, .location.n
 
 ### Debug Logging
 
-The game includes console.log statements in key areas:
+Debug logging was cleaned up from production code. Key areas for adding temporary debug logging when investigating issues:
 
-- Event triggers (`src/contexts/GameContext.tsx`)
-- State transitions (`src/core/state/reducers/gameReducer.ts`)
+- Store actions (`src/store/appStore.ts`)
 - Save/load operations (`src/core/persistence/saveLoad.ts`)
 
 Run the game in a terminal to see these logs in real-time:
@@ -358,7 +357,6 @@ Project documentation is organized across several locations:
 - `docs/primer.md` - Game mechanics, system design, and architecture evolution (Zustand migration)
 - `docs/persistence.md` - Save system design (5 slots), migration strategies, and best practices
 - `docs/testing.md` - Testing scenarios and patterns with AVA + ink-testing-library
-- `docs/roadmap.md` - Feature roadmap and pre-release cleanup tasks
 - `AGENTS.md` - Repository structure and coding guidelines for contributors
 
 ### Steering Documents (.kiro/steering/)

--- a/src/dev/TravelAnimationPreview.tsx
+++ b/src/dev/TravelAnimationPreview.tsx
@@ -1,15 +1,11 @@
 #!/usr/bin/env node
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import { Box, Text, render, useInput } from 'ink'
-import { AnimationManager } from '../core/animations/AnimationManager.js'
 import {
   AsciiAnimation,
   type AsciiAnimationControls,
 } from '../ui/components/common/AsciiAnimation.js'
-import {
-  createImmersiveTravelAnimation,
-  getLocationSpecificAnimation,
-} from '../ui/components/common/TravelAnimation.js'
+import { createImmersiveTravelAnimation } from '../ui/components/common/TravelAnimation.js'
 import type { TravelAnimation as TravelAnimationType } from '../types/animation.types.js'
 
 type PreviewOptions = {
@@ -85,54 +81,15 @@ function TravelAnimationPreviewApp({
   const isPausedReference = useRef<boolean>(isPaused)
 
   useEffect(() => {
-    let active = true
+    const immersive = createImmersiveTravelAnimation({
+      baseAnimation: fallbackBaseAnimation,
+      fromLocation,
+      toLocation,
+    })
 
-    const loadAnimation = async () => {
-      try {
-        setStatus('loading animations…')
-        const manager = AnimationManager.getInstance()
-        await manager.loadAnimations()
-
-        const locationSpecific =
-          getLocationSpecificAnimation(fromLocation, toLocation) ??
-          manager.getRandomTravelAnimation()
-
-        if (!active) {
-          return
-        }
-
-        const immersive = createImmersiveTravelAnimation({
-          baseAnimation: locationSpecific,
-          fromLocation,
-          toLocation,
-        })
-
-        setImmersiveAnimation(immersive)
-        setStatus('previewing')
-        setIterationCount(0)
-      } catch (error) {
-        console.warn('[preview] Failed to load travel animation library', error)
-        if (!active) {
-          return
-        }
-
-        const immersive = createImmersiveTravelAnimation({
-          baseAnimation: fallbackBaseAnimation,
-          fromLocation,
-          toLocation,
-        })
-
-        setImmersiveAnimation(immersive)
-        setStatus('using fallback animation')
-        setIterationCount(0)
-      }
-    }
-
-    void loadAnimation()
-
-    return () => {
-      active = false
-    }
+    setImmersiveAnimation(immersive)
+    setStatus('previewing')
+    setIterationCount(0)
   }, [fromLocation, toLocation, reloadIndex])
 
   useEffect(() => {

--- a/src/screens/GameScreen.tsx
+++ b/src/screens/GameScreen.tsx
@@ -1,6 +1,6 @@
 import { Box, Text } from 'ink'
 import Gradient from 'ink-gradient'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { HELP_TEXT, locations, potions } from '../constants.js'
 import { useStore } from '../store/appStore.js'
 import {
@@ -35,15 +35,9 @@ export function GameScreen() {
   const showEvent = useStore(selectShouldShowEvent)
   const showNPC = useStore(selectShouldShowNPC)
   const activeCombat = useStore(selectActiveCombat)
-  const locationName = useStore((state) => state.game.location.name)
   const currentNPCId = useStore((state) => state.npc.current?.npcId)
   const endNPCInteraction = useStore((state) => state.endNPCInteraction)
   const day = useStore((state) => state.game.day)
-
-  const [isTraveling, setIsTraveling] = useState(false)
-  const [previousLocation, setPreviousLocation] = useState<string | undefined>(
-    undefined
-  )
 
   // Tutorial system
   const {
@@ -93,26 +87,9 @@ export function GameScreen() {
     }
   }
 
-  // Track location changes for travel animation
-  useEffect(() => {
-    if (activeScreen === 'traveling' && !previousLocation) {
-      setPreviousLocation(locationName)
-    } else if (activeScreen === 'game' && previousLocation) {
-      setPreviousLocation(undefined)
-    }
-  }, [activeScreen, locationName, previousLocation])
-
   // Show traveling screen when screen state is 'traveling'
-  if (activeScreen === 'traveling' || isTraveling) {
-    return (
-      <TravelingScreen
-        fromLocation={previousLocation}
-        onFinish={() => {
-          setIsTraveling(false)
-          // Note: Screen transition back to 'game' is handled by the travel action
-        }}
-      />
-    )
+  if (activeScreen === 'traveling') {
+    return <TravelingScreen />
   }
 
   if (activeCombat) {

--- a/src/screens/NPCInteractionScreen.tsx
+++ b/src/screens/NPCInteractionScreen.tsx
@@ -19,8 +19,8 @@ export function NPCInteractionScreen({
   npc,
   onComplete,
 }: NPCInteractionScreenProperties) {
-  const gameState = useStore((state) => state.game)
   const addMessage = useStore((state) => state.addMessage)
+  const applyDialogueChoice = useStore((state) => state.applyDialogueChoice)
 
   const [currentNode, setCurrentNode] = useState<DialogueNode | undefined>(undefined)
   const [conversationHistory, setConversationHistory] = useState<string[]>([])
@@ -39,10 +39,12 @@ export function NPCInteractionScreen({
     }
   })
 
-  // Initialize dialogue
+  // Initialize dialogue once per NPC (reading latest gameState via getState to
+  // avoid re-running whenever cash/day/inventory changes mid-conversation).
   useEffect(() => {
     try {
-      const initialNode = DialogueEngine.processDialogue(npc, gameState)
+      const gameSnapshot = useStore.getState().game
+      const initialNode = DialogueEngine.processDialogue(npc, gameSnapshot)
       setCurrentNode(initialNode)
       setAnimationType('talking')
       setIsLoading(false)
@@ -79,7 +81,7 @@ export function NPCInteractionScreen({
       addMessage('error', 'Failed to start conversation')
       onComplete()
     }
-  }, [npc, gameState, addMessage, onComplete, showHint])
+  }, [npc.id])
 
   const handleChoiceSelection = useCallback(
     ({ value }: { value: string }) => {
@@ -98,25 +100,17 @@ export function NPCInteractionScreen({
         `You: ${selectedChoice.text}`,
       ])
 
-      // Apply choice effects to game state
+      // Apply choice effects to the store, then read the updated state for
+      // next-node condition evaluation.
       try {
-        const newGameState = DialogueEngine.handleChoice(
-          selectedChoice,
-          gameState,
-          npc.location
-        )
-
-        // Update game state if there were changes
-        if (newGameState !== gameState) {
-          // Note: In a real implementation, we'd need to update the game state through the context
-          // For now, we'll just apply the changes
-        }
+        applyDialogueChoice(selectedChoice, npc.location)
+        const updatedGameState = useStore.getState().game
 
         // Get next dialogue node
         const nextNode = DialogueEngine.getNextNode(
           npc,
           selectedChoice,
-          newGameState
+          updatedGameState
         )
 
         if (!nextNode) {
@@ -169,7 +163,7 @@ export function NPCInteractionScreen({
         onComplete()
       }
     },
-    [currentNode, gameState, npc, addMessage, onComplete]
+    [currentNode, npc, addMessage, onComplete, applyDialogueChoice]
   )
 
   if (isLoading) {

--- a/src/screens/TravelingScreen.tsx
+++ b/src/screens/TravelingScreen.tsx
@@ -1,76 +1,159 @@
 import { Box, Text, useInput } from 'ink'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
+import { locations } from '../constants.js'
 import { useStore } from '../store/appStore.js'
+import type { TimeOfDay } from '../types/animation.types.js'
+import { type AsciiAnimationControls } from '../ui/components/common/AsciiAnimation.js'
 import { TravelAnimation } from '../ui/components/common/TravelAnimation.js'
 
 type TravelingScreenProperties = {
-  readonly onFinish: () => void
-  readonly fromLocation?: string
+  readonly onFinish?: () => void
 }
 
-export function TravelingScreen({
-  onFinish,
-  fromLocation,
-}: TravelingScreenProperties) {
-  const [timeLeft, setTimeLeft] = useState(4)
-  const [showAnimation, setShowAnimation] = useState(true)
-  const [flavorText, setFlavorText] = useState('')
-  const [hasCompleted, setHasCompleted] = useState(false)
+// Scale travel duration by the destination's danger level. Safe villages feel
+// like a quick stroll; dangerous quarters feel like a longer, tenser trek.
+const TRAVEL_BASE_DURATION_MS = 2000
+const TRAVEL_MS_PER_DANGER = 400
+const TRAVEL_MIN_DURATION_MS = 1800
+const TRAVEL_MAX_DURATION_MS = 6000
+// Hard ceiling so travel can never get stuck if the animation fails to emit
+// onComplete for any reason (e.g. unmount race).
+const TRAVEL_SAFETY_CUSHION_MS = 2000
 
-  // Get state and actions from Zustand store
+const SPEED_STEP = 0.25
+const SPEED_MIN = 0.5
+const SPEED_MAX = 3
+
+const TIME_OF_DAY_CYCLE: TimeOfDay[] = ['dawn', 'day', 'dusk', 'night']
+
+function resolveDestinationDanger(destinationName: string | undefined): number {
+  if (!destinationName) {
+    return 3
+  }
+
+  const destination = locations.find(
+    (location) => location.name === destinationName
+  )
+  return destination?.dangerLevel ?? 3
+}
+
+function computeTravelDurationMs(dangerLevel: number): number {
+  const raw = TRAVEL_BASE_DURATION_MS + dangerLevel * TRAVEL_MS_PER_DANGER
+  return Math.max(
+    TRAVEL_MIN_DURATION_MS,
+    Math.min(TRAVEL_MAX_DURATION_MS, raw)
+  )
+}
+
+function computeTimeOfDay(day: number): TimeOfDay {
+  const index = ((day % TIME_OF_DAY_CYCLE.length) + TIME_OF_DAY_CYCLE.length) %
+    TIME_OF_DAY_CYCLE.length
+  return TIME_OF_DAY_CYCLE[index] ?? 'day'
+}
+
+export function TravelingScreen({ onFinish }: TravelingScreenProperties) {
   const day = useStore((state) => state.game.day)
-  const locationName = useStore((state) => state.game.location.name)
+  const origin = useStore((state) => state.travel.origin)
+  const destination = useStore((state) => state.travel.destination)
+  const weather = useStore((state) => state.game.weather)
   const completeTravel = useStore((state) => state.completeTravel)
 
-  // Initialize flavor text on mount
-  useEffect(() => {
-    setFlavorText(getTravelFlavorText(locationName))
-  }, [locationName])
+  const [hasCompleted, setHasCompleted] = useState(false)
+  const [isPaused, setIsPaused] = useState(false)
+  const [speedMultiplier, setSpeedMultiplier] = useState(1)
+  const completionTriggered = useRef(false)
+  const animationControls = useRef<AsciiAnimationControls | null>(null)
 
-  // Update flavor text every 2 seconds to make it more interesting
+  const dangerLevel = useMemo(
+    () => resolveDestinationDanger(destination),
+    [destination]
+  )
+  const durationMs = useMemo(
+    () => computeTravelDurationMs(dangerLevel),
+    [dangerLevel]
+  )
+  const timeOfDay = useMemo(() => computeTimeOfDay(day), [day])
+
+  const finishTravel = () => {
+    if (completionTriggered.current) {
+      return
+    }
+
+    completionTriggered.current = true
+    setHasCompleted(true)
+    completeTravel()
+    onFinish?.()
+  }
+
+  // Safety net: if the animation never emits onComplete (unmount race,
+  // terminal quirk, etc.) force completion after duration + cushion.
   useEffect(() => {
-    const flavorTimer = setInterval(() => {
-      setFlavorText(getTravelFlavorText(locationName))
-    }, 2000)
+    // When paused or running slow, stretch the safety timeout so it doesn't
+    // fire while the user is deliberately lingering on the scene.
+    const stretchFactor = isPaused ? 0 : 1 / Math.max(0.25, speedMultiplier)
+    if (stretchFactor === 0) {
+      return
+    }
+
+    const timeoutId = setTimeout(
+      finishTravel,
+      durationMs * stretchFactor + TRAVEL_SAFETY_CUSHION_MS
+    )
 
     return () => {
-      clearInterval(flavorTimer)
+      clearTimeout(timeoutId)
     }
-  }, [locationName])
+  }, [durationMs, isPaused, speedMultiplier])
 
+  // Apply pause state via imperative controls so we can resume without
+  // restarting the animation from frame 0.
   useEffect(() => {
-    const timer = setInterval(() => {
-      setTimeLeft((previous) => previous - 1)
-    }, 1000)
-
-    return () => {
-      clearInterval(timer)
+    const controls = animationControls.current
+    if (!controls) {
+      return
     }
-  }, [])
 
-  useEffect(() => {
-    if (timeLeft === 0 && !hasCompleted) {
-      setHasCompleted(true)
-      // Complete travel using store action (synchronous!)
-      completeTravel()
-      // Call parent callback
-      onFinish()
+    if (isPaused) {
+      controls.pause()
+    } else {
+      controls.start()
     }
-  }, [timeLeft, onFinish, completeTravel, hasCompleted])
+  }, [isPaused])
 
-  useInput((input) => {
-    if (input === '\r' && !hasCompleted) {
-      setHasCompleted(true)
-      // Complete travel using store action (synchronous!)
-      completeTravel()
-      // Call parent callback
-      onFinish()
+  useInput((input, key) => {
+    if (hasCompleted) {
+      return
+    }
+
+    if (input === '\r' || key.return) {
+      finishTravel()
+      return
+    }
+
+    if (input === ' ') {
+      setIsPaused((previous) => !previous)
+      return
+    }
+
+    if (input === '+' || input === '=') {
+      setSpeedMultiplier((previous) =>
+        Math.min(SPEED_MAX, Number((previous + SPEED_STEP).toFixed(2)))
+      )
+      return
+    }
+
+    if (input === '-' || input === '_') {
+      setSpeedMultiplier((previous) =>
+        Math.max(SPEED_MIN, Number((previous - SPEED_STEP).toFixed(2)))
+      )
     }
   })
 
-  const handleAnimationComplete = () => {
-    setShowAnimation(false)
-  }
+  const controlsLine = useMemo(() => {
+    const speedLabel = `×${speedMultiplier.toFixed(2).replace(/\.?0+$/, '')}`
+    const pauseLabel = isPaused ? 'paused' : 'running'
+    return `Enter skip · Space ${pauseLabel} · +/- speed ${speedLabel}`
+  }, [isPaused, speedMultiplier])
 
   return (
     <Box
@@ -79,83 +162,34 @@ export function TravelingScreen({
       justifyContent="center"
       height="100%"
     >
-      <Box flexDirection="column" alignItems="center" marginBottom={2}>
+      <Box flexDirection="column" alignItems="center" marginBottom={1}>
         <Text bold color="cyan">
           Day {day}
         </Text>
-        <Text>Traveling to {locationName}</Text>
-        {fromLocation && <Text dimColor>From {fromLocation}</Text>}
+        {origin && destination && (
+          <Text dimColor>
+            {origin} → {destination}
+          </Text>
+        )}
       </Box>
 
-      {/* Travel Animation */}
-      {showAnimation && (
-        <Box flexDirection="column" alignItems="center" marginBottom={2}>
-          <TravelAnimation
-            fromLocation={fromLocation || 'Unknown'}
-            toLocation={locationName}
-            onComplete={handleAnimationComplete}
-          />
-        </Box>
-      )}
+      <TravelAnimation
+        ref={animationControls}
+        fromLocation={origin ?? 'Unknown'}
+        toLocation={destination ?? 'Unknown'}
+        durationMs={durationMs}
+        dangerLevel={dangerLevel}
+        weather={weather}
+        timeOfDay={timeOfDay}
+        speedMultiplier={speedMultiplier}
+        onComplete={finishTravel}
+      />
 
-      {/* Progress indicator */}
-      <Box flexDirection="column" alignItems="center">
-        <Text>
-          {'█'.repeat(4 - timeLeft)}
-          {'░'.repeat(timeLeft)} {Math.round(((4 - timeLeft) / 4) * 100)}%
-        </Text>
-        <Text dimColor>Press Enter to skip ({timeLeft}s)</Text>
-      </Box>
-
-      {/* Travel tips or flavor text */}
-      <Box marginTop={2} width="60%" justifyContent="center">
-        <Text dimColor wrap="wrap">
-          {flavorText}
-        </Text>
+      <Box marginTop={1}>
+        <Text dimColor>{controlsLine}</Text>
       </Box>
     </Box>
   )
-}
-
-/**
- * Get flavor text for traveling to different locations
- */
-function getTravelFlavorText(locationName: string): string {
-  const flavorTexts: Record<string, string[]> = {
-    "Alchemist's Quarter": [
-      'The scent of brewing potions fills the air as you approach the quarter.',
-      'Smoke rises from countless chimneys, each hiding alchemical secrets.',
-      'You hear the bubbling of cauldrons and the clink of glass vials.',
-    ],
-    'Royal Castle': [
-      'The imposing towers of the castle loom ahead, guards watching your approach.',
-      'Banners flutter in the wind as you make your way to the royal grounds.',
-      'The sound of marching guards echoes through the stone corridors.',
-    ],
-    "Merchant's District": [
-      'The bustling sounds of commerce grow louder as you enter the district.',
-      'Merchants call out their wares while coins change hands rapidly.',
-      'The aroma of exotic spices and goods from distant lands fills the air.',
-    ],
-    'Enchanted Forest': [
-      'Ancient trees whisper secrets as you venture into the mystical woods.',
-      'Magical creatures dart between the shadows of towering oaks.',
-      'The very air seems to shimmer with arcane energy.',
-    ],
-    'Peasant Village': [
-      'Simple folk go about their daily tasks as you enter the humble village.',
-      'Chickens scatter as you walk down the dirt path between modest homes.',
-      'The smell of fresh bread and honest work welcomes you.',
-    ],
-  }
-
-  const texts = flavorTexts[locationName] || [
-    'You make your way through unfamiliar territory.',
-    'The journey continues as new sights unfold before you.',
-    'Each step brings you closer to your destination.',
-  ]
-
-  return texts[Math.floor(Math.random() * texts.length)] || texts[0]!
 }
 
 export default TravelingScreen

--- a/src/screens/tests/UpdatedTravelingScreen.test.tsx
+++ b/src/screens/tests/UpdatedTravelingScreen.test.tsx
@@ -2,71 +2,94 @@ import test from 'ava'
 import React from 'react'
 import { render } from 'ink-testing-library'
 import { TravelingScreen } from '../TravelingScreen.js'
-import { TestWrapper } from '../../core/state/tests/utils/TestWrapper.js'
 import { useStore } from '../../store/appStore.js'
 
 /**
- * Helper to pre-seed store and render TravelingScreen
+ * Seed the store with a travel-in-progress state and render TravelingScreen
+ * directly. We intentionally avoid TestWrapper here because it calls
+ * resetGame() during its own render pass, which would clobber the travel state
+ * we need to seed.
  */
-function renderTravelScreen(fromLocation?: string) {
-  const onFinish = () => {}
-
-  // Pre-seed store before render
+function renderTravelScreen({
+  origin,
+  destination,
+}: {
+  origin?: string
+  destination?: string
+} = {}) {
   useStore.getState().resetGame()
   useStore.setState((state) => {
     state.ui.activeScreen = 'traveling'
+    state.travel = {
+      phase: 'animating',
+      origin,
+      destination,
+      animationStartTime: Date.now(),
+    }
   })
 
-  return render(
-    <TestWrapper screen="traveling">
-      <TravelingScreen fromLocation={fromLocation} onFinish={onFinish} />
-    </TestWrapper>
-  )
+  return render(<TravelingScreen />)
 }
 
-test('Updated TravelingScreen shows travel animation', (t) => {
-  const { lastFrame, unmount } = renderTravelScreen('Market Square')
+test('TravelingScreen renders the animation scene', (t) => {
+  const { lastFrame, unmount } = renderTravelScreen({
+    origin: 'Peasant Village',
+    destination: 'Royal Castle',
+  })
 
   const output = lastFrame()
   t.truthy(output)
-  t.true(output!.includes('Traveling to'))
-  t.true(output!.includes('From Market Square'))
+  // The immersive scene is large — far more than a couple of header lines.
+  t.true((output?.length ?? 0) > 200)
   unmount()
 })
 
-test('Updated TravelingScreen shows progress indicator', (t) => {
-  const { lastFrame, unmount } = renderTravelScreen()
+test('TravelingScreen shows the route arrow when origin and destination are set', (t) => {
+  const { lastFrame, unmount } = renderTravelScreen({
+    origin: 'Peasant Village',
+    destination: 'Royal Castle',
+  })
 
   const output = lastFrame()
   t.truthy(output)
-  // Should show progress bar with blocks
-  t.true(
-    output!.includes('█') || output!.includes('░') || output!.includes('%')
-  )
+  t.true(output!.includes('Peasant Village'))
+  t.true(output!.includes('Royal Castle'))
+  t.true(output!.includes('→'))
   unmount()
 })
 
-test('Updated TravelingScreen shows flavor text', (t) => {
-  const { lastFrame, unmount } = renderTravelScreen('Market Square')
+test('TravelingScreen shows the percentage progress in the animation footer', (t) => {
+  const { lastFrame, unmount } = renderTravelScreen({
+    origin: 'Peasant Village',
+    destination: 'Royal Castle',
+  })
 
   const output = lastFrame()
   t.truthy(output)
-  // Should show some descriptive text about the journey
-  t.true(output!.length > 100) // Flavor text should make output longer
+  t.true(output!.includes('% complete'))
   unmount()
 })
 
-test('Updated TravelingScreen maintains skip functionality', (t) => {
-  const { lastFrame, unmount } = renderTravelScreen()
+test('TravelingScreen shows control hints', (t) => {
+  const { lastFrame, unmount } = renderTravelScreen({
+    origin: 'Peasant Village',
+    destination: 'Royal Castle',
+  })
 
   const output = lastFrame()
   t.truthy(output)
-  t.true(output!.includes('Press Enter to skip'))
+  t.true(output!.includes('Enter'))
+  t.true(output!.includes('skip'))
+  t.true(output!.includes('Space'))
+  t.true(output!.includes('speed'))
   unmount()
 })
 
-test('Updated TravelingScreen shows day information', (t) => {
-  const { lastFrame, unmount } = renderTravelScreen()
+test('TravelingScreen shows day information', (t) => {
+  const { lastFrame, unmount } = renderTravelScreen({
+    origin: 'Peasant Village',
+    destination: 'Royal Castle',
+  })
 
   const output = lastFrame()
   t.truthy(output)

--- a/src/store/appStore.ts
+++ b/src/store/appStore.ts
@@ -34,6 +34,8 @@ import { triggerRandomEvent } from '../core/events/index.js'
 import { checkNPCEncounter } from '../core/game/travel.js'
 import { calculateDamage } from '../core/combat/actions.js'
 import { generateEnemy } from '../core/combat/enemies.js'
+import { DialogueEngine } from '../core/dialogue/DialogueEngine.js'
+import { type DialogueChoice } from '../types/npc.types.js'
 import {
     saveGame as saveToDisk,
     loadGame as loadFromDisk,
@@ -172,6 +174,7 @@ export type AppStore = AppState & {
     interactionType: 'dialogue' | 'trade' | 'information'
   ) => void
   endNPCInteraction: () => void
+  applyDialogueChoice: (choice: DialogueChoice, npcLocation: string) => void
 
   // Combat actions
   startCombat: (enemy: Enemy) => void
@@ -367,6 +370,12 @@ export const useStore = create<AppStore>()(
             timestamp: Date.now(),
           })
         })
+
+        // Auto-save after repaying debt
+        const activeSlot = get().persistence.activeSlot
+        if (activeSlot > 0) {
+          get().saveGame(activeSlot)
+        }
       },
 
       startTravel(destination: string) {
@@ -474,9 +483,10 @@ export const useStore = create<AppStore>()(
             state.game.weather = weatherOptions[Math.floor(Math.random() * weatherOptions.length)]!
           }
 
-          // 5. Complete travel
+          // 5. Complete travel (reset to idle so future startTravel calls
+          // aren't gated by a stale 'complete' phase).
           state.travel = {
-            phase: 'complete',
+            phase: 'idle',
             destination: undefined,
             origin: undefined,
             animationStartTime: undefined,
@@ -530,6 +540,8 @@ export const useStore = create<AppStore>()(
       },
 
       advanceDay(triggerEvent = false, triggerDebt = false) {
+        let queuedEvent: MultiStepEvent | Event | undefined
+
         set((state) => {
           state.game.day += 1
 
@@ -546,10 +558,16 @@ export const useStore = create<AppStore>()(
           if (triggerEvent) {
             const eventResult = triggerRandomEvent(state.game)
             if (eventResult.currentEvent) {
-              get().triggerEvent(eventResult.currentEvent, 1)
+              queuedEvent = eventResult.currentEvent
             }
           }
         })
+
+        // Dispatch the follow-up action AFTER the set() commits to avoid
+        // nesting another set() inside an Immer producer.
+        if (queuedEvent) {
+          get().triggerEvent(queuedEvent, 1)
+        }
       },
 
       updateWeather(weather: Weather) {
@@ -614,11 +632,6 @@ export const useStore = create<AppStore>()(
       },
 
       chooseEvent(choiceIndex: number) {
-        // CRITICAL: This get() call MUST happen before set() to ensure proper state
-        // synchronization through the subscribeWithSelector + devtools + immer middleware stack.
-        // Without it, set() followed by get() can return stale state.
-        get().events.phase
-
         set((state) => {
           const { current, currentStep } = state.events
 
@@ -784,6 +797,17 @@ export const useStore = create<AppStore>()(
         if (activeSlot > 0) {
           get().saveGame(activeSlot)
         }
+      },
+
+      applyDialogueChoice(choice: DialogueChoice, npcLocation: string) {
+        set((state) => {
+          const newGameState = DialogueEngine.handleChoice(
+            choice,
+            state.game,
+            npcLocation,
+          )
+          Object.assign(state.game, newGameState)
+        })
       },
 
       // === Combat Actions ===
@@ -1098,10 +1122,20 @@ export const useStore = create<AppStore>()(
           state.game.prices = generateDynamicPrices(state.game)
 
           // Clear any active events/interactions
+          state.events.queue = []
           state.events.current = undefined
           state.events.phase = 'choice'
           state.events.currentStep = 0
           state.npc.current = undefined
+
+          // Reset transient travel/combat state so loading mid-action is clean
+          state.travel = {
+            phase: 'idle',
+            destination: undefined,
+            origin: undefined,
+            animationStartTime: undefined,
+          }
+          state.combat.active = undefined
 
           // Set screen to game
           state.ui.activeScreen = 'game'

--- a/src/store/tests/appStore.test.ts
+++ b/src/store/tests/appStore.test.ts
@@ -482,8 +482,11 @@ test('completeTravel: updates location and advances day', (t) => {
   // Verify day advanced
   t.is(after.game.day, initialDay + 1)
 
-  // Verify travel completed
-  t.is(after.travel.phase, 'complete')
+  // Verify travel completed (phase resets to 'idle' so subsequent startTravel
+  // calls aren't gated by a stale 'complete' marker).
+  t.is(after.travel.phase, 'idle')
+  t.is(after.travel.destination, undefined)
+  t.is(after.travel.origin, undefined)
 })
 
 // ==========================================

--- a/src/store/tests/synchronousUpdates.test.ts
+++ b/src/store/tests/synchronousUpdates.test.ts
@@ -137,7 +137,7 @@ test('travel completion: all state updates are synchronous', (t) => {
   t.is(currentState.game.location.name, 'Royal Castle')
   t.not(currentState.game.location.name, initialLocation)
   t.is(currentState.game.day, initialDay + 1)
-  t.is(currentState.travel.phase, 'complete')
+  t.is(currentState.travel.phase, 'idle')
   t.true(currentState.messages.some((m) => m.content.includes('Traveled from')))
 })
 
@@ -262,7 +262,7 @@ test('complex sequence: travel -> event -> choice all synchronous', (t) => {
 
   // Travel completed
   t.is(state.game.location.name, 'Royal Castle')
-  t.is(state.travel.phase, 'complete')
+  t.is(state.travel.phase, 'idle')
 
   // Event is active
   t.not(state.events.current, undefined)

--- a/src/types/animation.types.ts
+++ b/src/types/animation.types.ts
@@ -28,6 +28,9 @@ export type AnimationLibrary = {
 
 export type AnimationState = 'idle' | 'playing' | 'paused' | 'completed'
 
+/** Coarse time-of-day slots used to tint travel scenes. */
+export type TimeOfDay = 'dawn' | 'day' | 'dusk' | 'night'
+
 export type AnimationConfig = {
   frames: AnimationFrame[]
   duration?: number

--- a/src/ui/components/common/AsciiAnimation.tsx
+++ b/src/ui/components/common/AsciiAnimation.tsx
@@ -1,6 +1,17 @@
-import { Text } from 'ink'
+import { Box, Text } from 'ink'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import type { AnimationFrame } from '../../../types/animation.types.js'
+
+/**
+ * When provided, the animation renders each row as its own Text node so
+ * callers can colorize rows independently (useful for cinematic scenes like
+ * the travel animation).
+ */
+export type RowColorResolver = (
+  rowIndex: number,
+  rowContent: string,
+  frameIndex: number
+) => string | undefined
 
 type AsciiAnimationProperties = {
   readonly frames:
@@ -15,6 +26,7 @@ type AsciiAnimationProperties = {
   readonly externalState?: any
   readonly autoStart?: boolean
   readonly validateFrames?: boolean
+  readonly colorByRow?: RowColorResolver
 }
 
 const AsciiAnimationComponent = React.forwardRef<
@@ -32,6 +44,7 @@ const AsciiAnimationComponent = React.forwardRef<
       externalState,
       autoStart = true,
       validateFrames = true,
+      colorByRow,
     },
     reference
   ) => {
@@ -174,6 +187,19 @@ const AsciiAnimationComponent = React.forwardRef<
       }),
       [start, pause, stop, reset, isPlaying, isCompleted, frameIndex, iteration]
     )
+
+    if (colorByRow) {
+      const rows = getCurrentFrame().split('\n')
+      return (
+        <Box flexDirection="column">
+          {rows.map((row, index) => (
+            <Text key={index} color={colorByRow(index, row, frameIndex)}>
+              {row}
+            </Text>
+          ))}
+        </Box>
+      )
+    }
 
     return <Text>{getCurrentFrame()}</Text>
   }

--- a/src/ui/components/common/TravelAnimation.tsx
+++ b/src/ui/components/common/TravelAnimation.tsx
@@ -1,218 +1,86 @@
-import React, { useEffect, useMemo, useState } from 'react'
-import { AnimationManager } from '../../../core/animations/AnimationManager.js'
+import React, { useMemo } from 'react'
 import type {
   TravelAnimation as TravelAnimationType,
   AnimationFrame,
+  TimeOfDay,
 } from '../../../types/animation.types.js'
-import { AsciiAnimation } from './AsciiAnimation.js'
+import type { Weather } from '../../../types/weather.types.js'
+import {
+  AsciiAnimation,
+  type AsciiAnimationControls,
+  type RowColorResolver,
+} from './AsciiAnimation.js'
 
 type TravelAnimationProperties = {
   readonly fromLocation: string
   readonly toLocation: string
   readonly onComplete: () => void
   readonly autoStart?: boolean
+  readonly durationMs?: number
+  readonly dangerLevel?: number
+  readonly weather?: Weather
+  readonly timeOfDay?: TimeOfDay
+  readonly speedMultiplier?: number
 }
 
-export function TravelAnimation({
-  fromLocation,
-  toLocation,
-  onComplete,
-  autoStart = true,
-}: TravelAnimationProperties) {
-  const [animation, setAnimation] = useState<TravelAnimationType | undefined>(
-    undefined
+export const TravelAnimation = React.forwardRef<
+  AsciiAnimationControls,
+  TravelAnimationProperties
+>(function TravelAnimation(
+  {
+    fromLocation,
+    toLocation,
+    onComplete,
+    autoStart = true,
+    durationMs,
+    dangerLevel,
+    weather = 'sunny',
+    timeOfDay = 'day',
+    speedMultiplier = 1,
+  },
+  ref
+) {
+  const scene = useMemo(
+    () =>
+      createImmersiveTravelAnimation({
+        fromLocation,
+        toLocation,
+        durationMs,
+        dangerLevel,
+        weather,
+        timeOfDay,
+      }),
+    [fromLocation, toLocation, durationMs, dangerLevel, weather, timeOfDay]
   )
-  const [isLoaded, setIsLoaded] = useState(false)
 
-  useEffect(() => {
-    let isActive = true
+  const effectiveSpeed = useMemo(() => {
+    const multiplier = Math.max(0.25, Math.min(4, speedMultiplier))
+    return Math.max(MIN_PER_FRAME_MS, Math.round(scene.duration / multiplier))
+  }, [scene.duration, speedMultiplier])
 
-    const loadAnimation = async () => {
-      try {
-        const animationManager = AnimationManager.getInstance()
-        await animationManager.loadAnimations()
-
-        const locationSpecific = getLocationSpecificAnimation(
-          fromLocation,
-          toLocation
-        )
-        const travelAnimation =
-          locationSpecific ?? animationManager.getRandomTravelAnimation()
-
-        if (!isActive) {
-          return
-        }
-
-        setAnimation(travelAnimation)
-        setIsLoaded(true)
-      } catch (error) {
-        console.warn('Failed to load travel animation:', error)
-        // Use fallback animation
-        if (!isActive) {
-          return
-        }
-
-        setAnimation(getFallbackTravelAnimation(fromLocation, toLocation))
-        setIsLoaded(true)
-      }
-    }
-
-    loadAnimation()
-
-    return () => {
-      isActive = false
-    }
-  }, [fromLocation, toLocation])
-
-  const immersiveAnimation = useMemo(() => {
-    if (!animation) {
-      return null
-    }
-
-    return createImmersiveTravelAnimation({
-      baseAnimation: animation,
-      fromLocation,
-      toLocation,
-    })
-  }, [animation, fromLocation, toLocation])
-
-  if (!isLoaded || !immersiveAnimation) {
-    return <AsciiAnimation autoStart isLooping frames={getLoadingAnimation()} />
-  }
+  const colorByRow = useMemo(
+    () => createRowColorResolver({ weather, timeOfDay }),
+    [weather, timeOfDay]
+  )
 
   return (
     <AsciiAnimation
-      isLooping // Loop animations for the entire travel duration
-      frames={immersiveAnimation.frames}
-      speed={immersiveAnimation.duration}
+      ref={ref}
+      frames={scene.frames}
+      speed={effectiveSpeed}
+      isLooping={false}
+      loopCount={1}
       autoStart={autoStart}
       validateFrames={false}
       onComplete={onComplete}
+      colorByRow={colorByRow}
     />
   )
-}
+})
 
-// Helper functions
-function getLoadingAnimation(): AnimationFrame[] {
-  return [
-    [
-      'Preparing expedition supplies...',
-      '  Packing satchels and polishing glassware',
-      '  Infusing travel potions for steady footing',
-      '                       ',
-      '           ✦           ',
-    ],
-    [
-      'Preparing expedition supplies...',
-      '  Checking compass alignment and map runes',
-      '  Infusing travel potions for steady footing',
-      '                       ',
-      '             ✦         ',
-    ],
-    [
-      'Preparing expedition supplies...',
-      '  Checking compass alignment and map runes',
-      '  Whispering wards against roadside ambushes',
-      '                       ',
-      '               ✦       ',
-    ],
-  ]
-}
-
-function getFallbackTravelAnimation(
-  fromLocation: string,
-  toLocation: string
-): TravelAnimationType {
-  return {
-    name: 'Default Travel',
-    description: `Traveling from ${fromLocation} to ${toLocation}`,
-    duration: 800, // Increased from 500ms to 800ms per frame for smoother animation
-    frames: [
-      [
-        `Leaving ${fromLocation}...`,
-        '                          ',
-        '   o                      ',
-        '  /|\\                     ',
-        '  / \\                     ',
-        '                          ',
-      ],
-      [
-        'Traveling...',
-        '                          ',
-        '        o                 ',
-        '       /|\\                ',
-        '       / \\                ',
-        '                          ',
-      ],
-      [
-        'Traveling...',
-        '                          ',
-        '             o            ',
-        '            /|\\           ',
-        '            / \\           ',
-        '                          ',
-      ],
-      [
-        'Almost there...',
-        '                          ',
-        '                  o       ',
-        '                 /|\\      ',
-        '                 / \\      ',
-        '                          ',
-      ],
-      [
-        `Arriving at ${toLocation}!`,
-        '                          ',
-        '                      o   ',
-        '                     /|\\  ',
-        '                     / \\  ',
-        '                          ',
-      ],
-    ],
-  }
-}
-
-// Location-specific travel animations
-export function getLocationSpecificAnimation(
-  fromLocation: string,
-  toLocation: string
-): TravelAnimationType | undefined {
-  // This could be expanded to include specific animations for certain location pairs
-  const locationPairs: Record<string, TravelAnimationType> = {
-    'Market Square->Alchemist Quarter': {
-      name: 'Market to Alchemist',
-      description:
-        'Walking through the busy market to the quiet alchemist quarter',
-      duration: 1333, // 3 frames × 1333ms = ~4 seconds total
-      frames: [
-        [
-          'Leaving the bustling market...',
-          '                             ',
-          '  🏪  o  🏪                  ',
-          '     /|\\                     ',
-          '     / \\                     ',
-        ],
-        [
-          'Walking through the streets...',
-          '                             ',
-          '       o                     ',
-          '      /|\\                    ',
-          '      / \\                    ',
-        ],
-        [
-          'Entering the alchemist quarter...',
-          '                               ',
-          '  ⚗️   o   ⚗️                  ',
-          '      /|\\                      ',
-          '      / \\                      ',
-        ],
-      ],
-    },
-  }
-
-  const key = `${fromLocation}->${toLocation}`
-  return locationPairs[key] || undefined
-}
+// ===========================================================================
+// Scene constants
+// ===========================================================================
 
 const IMMERSIVE_FRAME_COUNT = 36
 const SCENE_WIDTH = 64
@@ -222,6 +90,16 @@ const SKY_START = 0
 const HORIZON_ROW = SKY_START + SKY_HEIGHT
 const PATH_TOP = HORIZON_ROW + 1
 const FOOTER_START = SCENE_HEIGHT - 3
+const BIOME_ROW = HORIZON_ROW - 1
+
+const DEFAULT_TOTAL_DURATION_MS = 3500
+const MIN_TOTAL_DURATION_MS = 1500
+const MAX_TOTAL_DURATION_MS = 9000
+const MIN_PER_FRAME_MS = 40
+
+// ===========================================================================
+// Sprites and decor
+// ===========================================================================
 
 type TravelerStage = {
   readonly maxProgress: number
@@ -284,20 +162,96 @@ const CLOUD_BANDS: Array<{
 
 const DESTINATION_MARKERS = ['✶', '✷', '✸', '✹']
 
+/**
+ * Per-destination approach silhouettes. Rendered just above the horizon once
+ * the traveler is past ~35% of the journey so the destination visibly
+ * "comes into view". Patterns are padded/trimmed to SCENE_WIDTH at render.
+ */
+const BIOME_SILHOUETTES: Record<string, string> = {
+  'Royal Castle':
+    '      _|_       _|_|_|_       _|_       _|_|_       _|_       ',
+  'Enchanted Forest':
+    '   Y  ♣  Y   ♠  Y  ♣   Y   ♠  Y   Y  ♣   ♠  Y   ♣  Y   ♠  Y   ',
+  "Alchemist's Quarter":
+    '     || ~    || ~      || ~   || ~      || ~   || ~   || ~    ',
+  "Merchant's District":
+    '    [==]    [==]    [===]    [==]    [===]    [==]    [==]    ',
+  'Peasant Village':
+    '        /\\          /\\           /\\         /\\            /\\   ',
+}
+
+// Narrative beats shown at the bottom of the scene. Four slots keyed by
+// progress quarter; weather variants override the generic copy.
+const DEFAULT_BEATS = [
+  'Setting out with steady steps',
+  'Midway markers slip past quietly',
+  'Night whispers along the roadside',
+  'Lantern glow beckons at the gate',
+]
+
+const WEATHER_BEATS: Record<Weather, string[] | undefined> = {
+  sunny: undefined,
+  rainy: [
+    'Rain patters on your cloak',
+    'Puddles swallow your footfalls',
+    'The downpour steadies to a hush',
+    'Wet lantern light flickers ahead',
+  ],
+  stormy: [
+    'Thunder grumbles over the hills',
+    'Lightning gilds the road briefly',
+    'The storm crashes all around you',
+    'Shelter looms through the rain',
+  ],
+  windy: [
+    'Wind tugs at your travel cloak',
+    'Gusts scatter leaves across the path',
+    'The wind howls through the hollows',
+    'Calmer air wraps the gate ahead',
+  ],
+  foggy: [
+    'Mist shrouds the road ahead',
+    'Grey drifts muffle every sound',
+    'Shapes loom half-seen in the fog',
+    'Lanterns bloom through the haze',
+  ],
+}
+
+// ===========================================================================
+// Public scene builder
+// ===========================================================================
+
 type ImmersiveAnimationOptions = {
   fromLocation: string
   toLocation: string
-  baseAnimation: TravelAnimationType
+  durationMs?: number
+  dangerLevel?: number
+  weather?: Weather
+  timeOfDay?: TimeOfDay
+  /**
+   * Legacy knob kept for the dev preview tool. Only used to derive a default
+   * duration when `durationMs` is not supplied.
+   */
+  baseAnimation?: TravelAnimationType
 }
 
-type FrameOptions = ImmersiveAnimationOptions & {
+type FrameOptions = {
+  fromLocation: string
+  toLocation: string
   frameIndex: number
   totalFrames: number
+  dangerLevel: number
+  weather: Weather
+  timeOfDay: TimeOfDay
 }
 
 export function createImmersiveTravelAnimation(
   options: ImmersiveAnimationOptions
 ): TravelAnimationType {
+  const weather: Weather = options.weather ?? 'sunny'
+  const timeOfDay: TimeOfDay = options.timeOfDay ?? 'day'
+  const dangerLevel = clamp(options.dangerLevel ?? 3, 1, 9)
+
   const frames: AnimationFrame[] = []
 
   for (
@@ -307,43 +261,87 @@ export function createImmersiveTravelAnimation(
   ) {
     frames.push(
       buildImmersiveFrame({
-        ...options,
+        fromLocation: options.fromLocation,
+        toLocation: options.toLocation,
         frameIndex,
         totalFrames: IMMERSIVE_FRAME_COUNT,
+        dangerLevel,
+        weather,
+        timeOfDay,
       })
     )
   }
 
-  const baseFrameCount =
-    options.baseAnimation.frames.length > 0
-      ? options.baseAnimation.frames.length
-      : 1
-  const baseTotalDuration = options.baseAnimation.duration * baseFrameCount
-  const totalDuration = Math.max(5200, Math.round(baseTotalDuration * 1.25))
+  const totalDuration = resolveTotalDuration(options)
   const perFrameDuration = Math.max(
-    90,
+    MIN_PER_FRAME_MS,
     Math.round(totalDuration / IMMERSIVE_FRAME_COUNT)
   )
 
+  const name = options.baseAnimation
+    ? `${options.baseAnimation.name} Journey`
+    : 'Travel Journey'
+
   return {
-    name: `${options.baseAnimation.name} Journey`,
+    name,
     description: `Journey from ${options.fromLocation} to ${options.toLocation}`,
     duration: perFrameDuration,
     frames,
   }
 }
 
+function resolveTotalDuration(options: ImmersiveAnimationOptions): number {
+  if (typeof options.durationMs === 'number' && options.durationMs > 0) {
+    return clamp(
+      options.durationMs,
+      MIN_TOTAL_DURATION_MS,
+      MAX_TOTAL_DURATION_MS
+    )
+  }
+
+  if (options.baseAnimation) {
+    const baseFrameCount =
+      options.baseAnimation.frames.length > 0
+        ? options.baseAnimation.frames.length
+        : 1
+    const baseTotal = options.baseAnimation.duration * baseFrameCount
+    return clamp(
+      Math.round(baseTotal * 1.25),
+      MIN_TOTAL_DURATION_MS,
+      MAX_TOTAL_DURATION_MS
+    )
+  }
+
+  return DEFAULT_TOTAL_DURATION_MS
+}
+
+// ===========================================================================
+// Frame builder
+// ===========================================================================
+
 function buildImmersiveFrame(options: FrameOptions): AnimationFrame {
-  const { frameIndex, totalFrames, fromLocation, toLocation } = options
+  const {
+    frameIndex,
+    totalFrames,
+    fromLocation,
+    toLocation,
+    dangerLevel,
+    weather,
+    timeOfDay,
+  } = options
   const grid = createEmptyGrid(SCENE_WIDTH, SCENE_HEIGHT)
   const progress = totalFrames <= 1 ? 0 : frameIndex / (totalFrames - 1)
 
-  renderSky(grid, frameIndex, progress)
+  renderSky(grid, frameIndex, progress, timeOfDay, weather)
+  renderBiomeSilhouette(grid, toLocation, progress)
   renderLandscape(grid, frameIndex)
   renderRoad(grid, frameIndex, progress)
+  renderDangerAccents(grid, frameIndex, dangerLevel)
   renderDestinationMarker(grid, toLocation, frameIndex)
   renderTraveler(grid, frameIndex, progress)
-  renderFooter(grid, fromLocation, toLocation, progress)
+  // Weather runs late so rain/fog drifts across anything still empty.
+  renderWeatherOverlay(grid, frameIndex, weather)
+  renderFooter(grid, fromLocation, toLocation, progress, weather)
 
   return grid.map((row) => row.join(''))
 }
@@ -351,38 +349,95 @@ function buildImmersiveFrame(options: FrameOptions): AnimationFrame {
 function renderSky(
   grid: string[][],
   frameIndex: number,
-  progress: number
+  progress: number,
+  timeOfDay: TimeOfDay,
+  weather: Weather
 ): void {
   for (let offset = 0; offset < SKY_HEIGHT; offset += 1) {
     const fillChar = offset >= SKY_HEIGHT - 2 ? '.' : ' '
     setRow(grid, SKY_START + offset, fillChar.repeat(SCENE_WIDTH))
   }
 
-  for (const band of CLOUD_BANDS) {
-    const row = SKY_START + band.rowOffset
-    if (row < SKY_START || row >= SKY_START + SKY_HEIGHT) {
-      continue
-    }
+  // Clouds: skip for storms — the weather overlay handles that texture.
+  if (weather !== 'stormy' && weather !== 'foggy') {
+    for (const band of CLOUD_BANDS) {
+      const row = SKY_START + band.rowOffset
+      if (row < SKY_START || row >= SKY_START + SKY_HEIGHT) {
+        continue
+      }
 
-    const travel =
-      (frameIndex * band.speed) % (SCENE_WIDTH + band.pattern.length)
-    const start = Math.floor(travel) - band.pattern.length
-    writeText(grid, band.pattern, start, row)
+      const travel =
+        (frameIndex * band.speed) % (SCENE_WIDTH + band.pattern.length)
+      const start = Math.floor(travel) - band.pattern.length
+      writeText(grid, band.pattern, start, row)
+    }
   }
 
-  if (progress < 0.25 || progress > 0.65) {
+  renderCelestials(grid, frameIndex, progress, timeOfDay)
+}
+
+function renderCelestials(
+  grid: string[][],
+  frameIndex: number,
+  progress: number,
+  timeOfDay: TimeOfDay
+): void {
+  if (timeOfDay === 'night') {
     const starGlyph = frameIndex % 2 === 0 ? '✶' : '✷'
     for (const { x, y } of STAR_POSITIONS) {
       setChar(grid, x, y, starGlyph)
     }
+
+    const moonPosition = computeCelestialArc(progress)
+    setChar(grid, moonPosition.x, moonPosition.y, '☾')
+    return
   }
 
-  const sunPosition = computeCelestialPosition(progress)
-  setChar(grid, sunPosition.x, sunPosition.y, '☼')
+  if (timeOfDay === 'dawn') {
+    // Sun low on the left, a couple of stars fading
+    for (const [index, { x, y }] of STAR_POSITIONS.entries()) {
+      if (index % 3 === 0) {
+        setChar(grid, x, y, '·')
+      }
+    }
+    setChar(grid, 6, SKY_HEIGHT - 2, '☼')
+    return
+  }
 
-  const moonPosition = computeCelestialPosition((progress + 0.5) % 1)
-  const moonGlyph = progress > 0.5 ? '☾' : '☽'
-  setChar(grid, moonPosition.x, moonPosition.y, moonGlyph)
+  if (timeOfDay === 'dusk') {
+    // Sun low on the right, moon rising on the left
+    setChar(grid, SCENE_WIDTH - 8, SKY_HEIGHT - 2, '☼')
+    setChar(grid, 8, SKY_HEIGHT - 3, '☽')
+    return
+  }
+
+  // Daytime: sun arcs across as the journey progresses.
+  const sunPosition = computeCelestialArc(progress)
+  setChar(grid, sunPosition.x, sunPosition.y, '☼')
+}
+
+function renderBiomeSilhouette(
+  grid: string[][],
+  toLocation: string,
+  progress: number
+): void {
+  if (progress < 0.35) {
+    return
+  }
+
+  const pattern = BIOME_SILHOUETTES[toLocation]
+  if (!pattern) {
+    return
+  }
+
+  for (let x = 0; x < Math.min(pattern.length, SCENE_WIDTH); x += 1) {
+    const char = pattern[x]
+    if (!char || char === ' ') {
+      continue
+    }
+
+    setChar(grid, x, BIOME_ROW, char)
+  }
 }
 
 function renderLandscape(grid: string[][], frameIndex: number): void {
@@ -419,6 +474,29 @@ function renderRoad(
       const glyph = isGuide && (rowOffset + frameIndex) % 3 === 0 ? '|' : '.'
       setChar(grid, column, currentRow, glyph)
     }
+  }
+}
+
+function renderDangerAccents(
+  grid: string[][],
+  frameIndex: number,
+  dangerLevel: number
+): void {
+  if (dangerLevel < 5) {
+    return
+  }
+
+  const glyph = dangerLevel >= 7 ? '░' : ';'
+  const everyN = Math.max(2, 6 - dangerLevel) // denser at higher danger
+
+  for (let row = PATH_TOP; row < FOOTER_START; row += 1) {
+    if ((row + frameIndex) % everyN !== 0) {
+      continue
+    }
+
+    const jitter = (frameIndex + row) % 3
+    setCharIfEmpty(grid, jitter, row, glyph)
+    setCharIfEmpty(grid, SCENE_WIDTH - 1 - jitter, row, glyph)
   }
 }
 
@@ -476,11 +554,75 @@ function renderTraveler(
   writeSprite(grid, sprite, travelerX, travelerY)
 }
 
+function renderWeatherOverlay(
+  grid: string[][],
+  frameIndex: number,
+  weather: Weather
+): void {
+  if (weather === 'sunny') {
+    return
+  }
+
+  if (weather === 'rainy') {
+    for (let y = 0; y < FOOTER_START; y += 1) {
+      for (let x = (frameIndex + y * 2) % 7; x < SCENE_WIDTH; x += 7) {
+        setCharIfEmpty(grid, x, y, '/')
+      }
+    }
+
+    return
+  }
+
+  if (weather === 'stormy') {
+    // Denser rain than `rainy`.
+    for (let y = 0; y < FOOTER_START; y += 1) {
+      for (let x = (frameIndex + y * 2) % 4; x < SCENE_WIDTH; x += 4) {
+        setCharIfEmpty(grid, x, y, '/')
+      }
+    }
+
+    // Lightning strike every 6 frames. The colorByRow resolver lights the
+    // sky rows around the same phase so it reads as a flash.
+    if (frameIndex % 6 === 0) {
+      const baseX = ((frameIndex * 5) % (SCENE_WIDTH - 8)) + 4
+      setChar(grid, baseX, 0, '\\')
+      setChar(grid, baseX - 1, 1, '/')
+      setChar(grid, baseX, 2, '\\')
+      setChar(grid, baseX - 1, 3, '/')
+    }
+
+    return
+  }
+
+  if (weather === 'foggy') {
+    for (let x = 0; x < SCENE_WIDTH; x += 1) {
+      if ((x + frameIndex) % 3 !== 0) {
+        setChar(grid, x, 3, '~')
+      }
+
+      if ((x + frameIndex + 1) % 2 === 0) {
+        setChar(grid, x, 4, '~')
+      }
+    }
+
+    return
+  }
+
+  if (weather === 'windy') {
+    // Wind streaks across the landscape / lower sky.
+    for (let x = (frameIndex * 3) % 10; x < SCENE_WIDTH; x += 10) {
+      setCharIfEmpty(grid, x, SKY_HEIGHT - 2, '~')
+      setCharIfEmpty(grid, x + 2, SKY_HEIGHT - 1, '~')
+    }
+  }
+}
+
 function renderFooter(
   grid: string[][],
   fromLocation: string,
   toLocation: string,
-  progress: number
+  progress: number,
+  weather: Weather
 ): void {
   const routeText = `Route ${shortenLabel(fromLocation, 16)} -> ${shortenLabel(
     toLocation,
@@ -488,13 +630,7 @@ function renderFooter(
   )}`
   setRow(grid, FOOTER_START, centerWithin(routeText, SCENE_WIDTH))
 
-  const beats = [
-    'Setting out with steady steps',
-    'Midway markers slip past quietly',
-    'Night whispers along the roadside',
-    'Lantern glow beckons at the gate',
-  ]
-
+  const beats = WEATHER_BEATS[weather] ?? DEFAULT_BEATS
   const beatIndex =
     progress < 0.25 ? 0 : progress < 0.5 ? 1 : progress < 0.8 ? 2 : 3
   setRow(
@@ -509,7 +645,70 @@ function renderFooter(
   setRow(grid, FOOTER_START + 2, centerWithin(travelProgress, SCENE_WIDTH))
 }
 
-function computeCelestialPosition(progress: number): { x: number; y: number } {
+// ===========================================================================
+// Row color resolver
+// ===========================================================================
+
+type ColorResolverOptions = {
+  weather: Weather
+  timeOfDay: TimeOfDay
+}
+
+function createRowColorResolver(
+  options: ColorResolverOptions
+): RowColorResolver {
+  return (rowIndex: number, _row: string, frameIndex: number) => {
+    // Footer is always readable — don't let weather drown it out.
+    if (rowIndex === FOOTER_START) return 'yellow'
+    if (rowIndex === FOOTER_START + 1) return 'gray'
+    if (rowIndex === FOOTER_START + 2) return 'cyan'
+
+    // Road
+    if (rowIndex >= PATH_TOP && rowIndex < FOOTER_START) return 'gray'
+
+    // Horizon and stipple
+    if (rowIndex === HORIZON_ROW) return 'green'
+    if (rowIndex === HORIZON_ROW + 1) return 'greenBright'
+
+    // Biome silhouette row
+    if (rowIndex === BIOME_ROW) {
+      if (options.timeOfDay === 'night') return 'blueBright'
+      if (options.timeOfDay === 'dusk') return 'magenta'
+      return 'white'
+    }
+
+    // Sky — modulated by weather, then time-of-day, with a lightning flash
+    // during stormy weather for extra drama.
+    if (rowIndex < BIOME_ROW) {
+      if (options.weather === 'stormy') {
+        if (frameIndex % 6 === 0) return 'whiteBright'
+        return 'gray'
+      }
+
+      if (options.weather === 'foggy') return 'gray'
+      if (options.weather === 'rainy') return 'blue'
+
+      switch (options.timeOfDay) {
+        case 'dawn':
+          return 'yellow'
+        case 'dusk':
+          return 'magenta'
+        case 'night':
+          return 'blueBright'
+        default:
+          return 'cyan'
+      }
+    }
+
+    return undefined
+  }
+}
+
+// ===========================================================================
+// Low-level helpers
+// ===========================================================================
+
+function computeCelestialArc(progress: number): { x: number; y: number } {
   const clamped = clamp(progress, 0, 1)
   const x = clamp(
     Math.round(clamped * (SCENE_WIDTH - 5)) + 2,
@@ -571,6 +770,31 @@ function setChar(grid: string[][], x: number, y: number, char: string): void {
   }
 
   row[x] = char
+}
+
+function setCharIfEmpty(
+  grid: string[][],
+  x: number,
+  y: number,
+  char: string
+): void {
+  if (y < 0 || y >= grid.length) {
+    return
+  }
+
+  const row = grid[y]
+  if (!row) {
+    return
+  }
+
+  if (x < 0 || x >= row.length) {
+    return
+  }
+
+  const existing = row[x]
+  if (existing === ' ' || existing === '.') {
+    row[x] = char
+  }
 }
 
 function writeText(grid: string[][], text: string, x: number, y: number): void {

--- a/src/ui/components/common/tests/ImmersiveTravelAnimation.test.ts
+++ b/src/ui/components/common/tests/ImmersiveTravelAnimation.test.ts
@@ -2,7 +2,159 @@ import test from 'ava'
 import type { TravelAnimation as TravelAnimationType } from '../../../../types/animation.types.js'
 import { createImmersiveTravelAnimation } from '../TravelAnimation.js'
 
+const IMMERSIVE_FRAME_COUNT = 36
+
 test('createImmersiveTravelAnimation produces cinematic frames', (t) => {
+  const immersive = createImmersiveTravelAnimation({
+    fromLocation: 'Start',
+    toLocation: 'End',
+  })
+
+  t.is(immersive.frames.length, IMMERSIVE_FRAME_COUNT)
+  t.true(immersive.description.includes('Start'))
+  t.true(immersive.description.includes('End'))
+
+  const firstFrame = immersive.frames[0]
+  t.truthy(firstFrame)
+
+  const expectedWidth = firstFrame?.[0]?.length ?? 0
+  t.true(expectedWidth > 0)
+
+  // All frames must have consistent width so terminal rendering stays stable.
+  for (const frame of immersive.frames) {
+    for (const line of frame) {
+      t.is(line.length, expectedWidth)
+    }
+  }
+})
+
+test('createImmersiveTravelAnimation respects an explicit durationMs', (t) => {
+  const durationMs = 3000
+  const immersive = createImmersiveTravelAnimation({
+    fromLocation: 'Start',
+    toLocation: 'End',
+    durationMs,
+  })
+
+  const expectedPerFrame = Math.max(
+    40,
+    Math.round(durationMs / IMMERSIVE_FRAME_COUNT)
+  )
+  t.is(immersive.duration, expectedPerFrame)
+})
+
+test('createImmersiveTravelAnimation clamps very short durations', (t) => {
+  const immersive = createImmersiveTravelAnimation({
+    fromLocation: 'Start',
+    toLocation: 'End',
+    durationMs: 100, // Well below the minimum
+  })
+
+  // Per-frame duration must stay above the minimum to avoid terminal thrashing.
+  t.true(immersive.duration >= 40)
+})
+
+test('createImmersiveTravelAnimation renders biome silhouettes for known destinations', (t) => {
+  const immersive = createImmersiveTravelAnimation({
+    fromLocation: 'Peasant Village',
+    toLocation: 'Royal Castle',
+    durationMs: 3000,
+  })
+
+  // Biome silhouettes only kick in past progress >= 0.35. Frame 14 of 36 is
+  // ~0.40, so the castle silhouette should show up on its dedicated row.
+  const lateFrame = immersive.frames[14]
+  t.truthy(lateFrame)
+  const biomeRow = lateFrame![4] // BIOME_ROW = SKY_HEIGHT - 1 = 4
+  t.true(biomeRow!.includes('_|_'))
+})
+
+test('createImmersiveTravelAnimation skips biome silhouettes for unknown destinations', (t) => {
+  const immersive = createImmersiveTravelAnimation({
+    fromLocation: 'Nowhere',
+    toLocation: 'Somewhere Invented',
+    durationMs: 3000,
+  })
+
+  const lateFrame = immersive.frames[20]
+  t.truthy(lateFrame)
+  const biomeRow = lateFrame![4]
+  // No silhouette pattern = no `_|_` or tree/cottage glyphs
+  t.false(biomeRow!.includes('_|_'))
+  t.false(biomeRow!.includes('[=='))
+})
+
+test('createImmersiveTravelAnimation injects rain glyphs when weather is rainy', (t) => {
+  const rainy = createImmersiveTravelAnimation({
+    fromLocation: 'A',
+    toLocation: 'B',
+    weather: 'rainy',
+    durationMs: 3000,
+  })
+
+  const sunny = createImmersiveTravelAnimation({
+    fromLocation: 'A',
+    toLocation: 'B',
+    weather: 'sunny',
+    durationMs: 3000,
+  })
+
+  // Count how many `/` appear across sky rows (0..4) in frame 5. Rainy
+  // overlay should materially exceed the sunny baseline.
+  const skySlashCount = (animation: typeof rainy) =>
+    animation
+      .frames[5]!.slice(0, 5)
+      .join('')
+      .split('/')
+      .length - 1
+
+  t.true(skySlashCount(rainy) > skySlashCount(sunny) + 3)
+})
+
+test('createImmersiveTravelAnimation draws a fog band when weather is foggy', (t) => {
+  const foggy = createImmersiveTravelAnimation({
+    fromLocation: 'A',
+    toLocation: 'B',
+    weather: 'foggy',
+    durationMs: 3000,
+  })
+
+  // Fog band lives on rows 3 and 4.
+  const fogRow = foggy.frames[3]![3]
+  t.true(fogRow!.includes('~'))
+})
+
+test('createImmersiveTravelAnimation adds danger shadows on high-danger routes', (t) => {
+  const danger7 = createImmersiveTravelAnimation({
+    fromLocation: 'A',
+    toLocation: 'B',
+    dangerLevel: 7,
+    durationMs: 3000,
+  })
+
+  const danger2 = createImmersiveTravelAnimation({
+    fromLocation: 'A',
+    toLocation: 'B',
+    dangerLevel: 2,
+    durationMs: 3000,
+  })
+
+  // Flatten road rows and count shadow glyphs.
+  const countShadow = (animation: typeof danger7) => {
+    let total = 0
+    for (const frame of animation.frames) {
+      for (let r = 6; r < 17; r += 1) {
+        const row = frame[r] ?? ''
+        total += (row.match(/[░;]/g) ?? []).length
+      }
+    }
+    return total
+  }
+
+  t.true(countShadow(danger7) > countShadow(danger2) + 10)
+})
+
+test('createImmersiveTravelAnimation still supports legacy baseAnimation callers', (t) => {
   const baseAnimation: TravelAnimationType = {
     name: 'Base',
     description: 'Base animation for preview',
@@ -19,26 +171,7 @@ test('createImmersiveTravelAnimation produces cinematic frames', (t) => {
     toLocation: 'End',
   })
 
-  t.is(immersive.frames.length, 36)
-  const baseTotalDuration = baseAnimation.duration * baseAnimation.frames.length
-  const totalDuration = Math.max(5200, Math.round(baseTotalDuration * 1.25))
-  const expectedDuration = Math.max(
-    90,
-    Math.round(totalDuration / immersive.frames.length)
-  )
-  t.is(immersive.duration, expectedDuration)
-  t.true(immersive.description.includes('Start'))
-  t.true(immersive.description.includes('End'))
-
-  const firstFrame = immersive.frames[0]
-  t.truthy(firstFrame)
-
-  const expectedWidth = firstFrame?.[0]?.length ?? 0
-  t.true(expectedWidth > 0)
-
-  for (const frame of immersive.frames) {
-    for (const line of frame) {
-      t.is(line.length, expectedWidth)
-    }
-  }
+  t.is(immersive.frames.length, IMMERSIVE_FRAME_COUNT)
+  t.true(immersive.name.includes('Journey'))
+  t.true(immersive.duration >= 40)
 })

--- a/src/ui/components/common/tests/TravelAnimation.test.tsx
+++ b/src/ui/components/common/tests/TravelAnimation.test.tsx
@@ -1,190 +1,99 @@
 import test from 'ava'
 import React from 'react'
 import { render } from 'ink-testing-library'
-import {
-    TravelAnimation,
-    getLocationSpecificAnimation,
-} from '../TravelAnimation.js'
+import { TravelAnimation } from '../TravelAnimation.js'
 
-test('TravelAnimation renders with loading animation initially', (t) => {
+test('TravelAnimation renders immediately without a loading state', (t) => {
   const { lastFrame, unmount } = render(
     <TravelAnimation
-      fromLocation="Market Square"
-      toLocation="Alchemist Quarter"
       autoStart={false}
+      fromLocation="Peasant Village"
+      toLocation="Royal Castle"
       onComplete={() => {}}
     />
   )
 
-  // Should show loading animation immediately
-  const frame = lastFrame()
-  t.true(frame?.includes('Preparing') || frame?.includes('→') || false)
-  unmount()
-})
-
-test('TravelAnimation renders with location information', async (t) => {
-  const { lastFrame, unmount } = render(
-    <TravelAnimation
-      fromLocation="Market Square"
-      toLocation="Alchemist Quarter"
-      autoStart={false}
-      onComplete={() => {}}
-    />
-  )
-
-  // Wait for animation to load
-  await new Promise((resolve) => setTimeout(resolve, 100))
-
-  // Should render some content
   const frame = lastFrame()
   t.true((frame?.length ?? 0) > 0)
+  // The immersive scene always labels the destination in the footer/marker.
+  t.true(frame?.includes('Royal Castle') ?? false)
   unmount()
 })
 
-test('TravelAnimation calls onComplete callback', (t) => {
+test('TravelAnimation does not auto-complete when autoStart is false', (t) => {
   let completed = false
 
   const { unmount } = render(
     <TravelAnimation
-      fromLocation="Test Location A"
-      toLocation="Test Location B"
       autoStart={false}
+      fromLocation="Peasant Village"
+      toLocation="Royal Castle"
       onComplete={() => {
         completed = true
       }}
     />
   )
 
-  // The callback should be passed through (we can't easily test if it's called without starting the animation)
-  t.false(completed) // Should not be called yet since autoStart is false
+  t.false(completed)
   unmount()
 })
 
-test('TravelAnimation handles different location combinations', async (t) => {
+test('TravelAnimation handles different location combinations', (t) => {
   const { lastFrame: frame1, unmount: unmount1 } = render(
     <TravelAnimation
-      fromLocation="Location A"
-      toLocation="Location B"
       autoStart={false}
+      fromLocation="Enchanted Forest"
+      toLocation="Merchant's District"
       onComplete={() => {}}
     />
   )
 
   const { lastFrame: frame2, unmount: unmount2 } = render(
     <TravelAnimation
-      fromLocation="Different Place"
-      toLocation="Another Place"
       autoStart={false}
+      fromLocation="Alchemist's Quarter"
+      toLocation="Peasant Village"
       onComplete={() => {}}
     />
   )
 
-  // Wait for animations to load
-  await new Promise((resolve) => setTimeout(resolve, 100))
-
-  // Both should render content
   t.true((frame1()?.length ?? 0) > 0)
   t.true((frame2()?.length ?? 0) > 0)
   unmount1()
   unmount2()
 })
 
-test('TravelAnimation handles autoStart prop', async (t) => {
-  const { lastFrame: frame1, unmount: unmount1 } = render(
-    <TravelAnimation
-      autoStart
-      fromLocation="Start"
-      toLocation="End"
-      onComplete={() => {}}
-    />
-  )
-
-  const { lastFrame: frame2, unmount: unmount2 } = render(
-    <TravelAnimation
-      fromLocation="Start"
-      toLocation="End"
-      autoStart={false}
-      onComplete={() => {}}
-    />
-  )
-
-  // Both should render content
-  t.true((frame1()?.length ?? 0) > 0)
-  t.true((frame2()?.length ?? 0) > 0)
-  unmount1()
-  unmount2()
-})
-
-test('TravelAnimation gracefully handles animation loading errors', async (t) => {
-  // This should still work even if there are issues loading animations
+test('TravelAnimation honors a custom durationMs without errors', (t) => {
   const { lastFrame, unmount } = render(
     <TravelAnimation
-      fromLocation="Problematic Location With Very Long Name That Might Cause Issues"
-      toLocation="Another Problematic Location"
       autoStart={false}
+      fromLocation="Start"
+      toLocation="End"
+      durationMs={2500}
       onComplete={() => {}}
     />
   )
 
-  // Wait for fallback animation to load
-  await new Promise((resolve) => setTimeout(resolve, 150))
-
-  // Should still render something (fallback animation)
-  const frame = lastFrame()
-  t.true((frame?.length ?? 0) > 0)
+  t.true((lastFrame()?.length ?? 0) > 0)
   unmount()
 })
 
-test('getLocationSpecificAnimation returns specific animation for known pairs', (t) => {
-  const animation = getLocationSpecificAnimation(
-    'Market Square',
-    'Alchemist Quarter'
-  )
-
-  if (animation) {
-    t.is(typeof animation.name, 'string')
-    t.is(typeof animation.description, 'string')
-    t.is(typeof animation.duration, 'number')
-    t.true(Array.isArray(animation.frames))
-    t.true(animation.frames.length > 0)
-  } else {
-    // It's okay if no specific animation exists for this pair
-    t.pass()
-  }
-})
-
-test('getLocationSpecificAnimation returns null for unknown pairs', (t) => {
-  const animation = getLocationSpecificAnimation(
-    'Unknown Location A',
-    'Unknown Location B'
-  )
-
-  // Should return null for unknown location pairs
-  t.is(animation, undefined)
-})
-
-test('TravelAnimation shows travel progression', async (t) => {
+test('TravelAnimation renders a traveler glyph in the scene', (t) => {
   const { lastFrame, unmount } = render(
     <TravelAnimation
+      autoStart={false}
       fromLocation="Start Point"
       toLocation="End Point"
-      autoStart={false}
       onComplete={() => {}}
     />
   )
 
-  // Wait for animation to load
-  await new Promise((resolve) => setTimeout(resolve, 100))
-
   const frame = lastFrame()
-
-  // Should contain travel-related content
+  // Either the traveler's head or the route label should appear in frame 0.
   t.true(
-    frame?.includes('Start Point') ||
-      frame?.includes('End Point') ||
-      frame?.includes('Travel') ||
-      frame?.includes('→') ||
-      frame?.includes('o') || // Character representation
+    frame?.includes('End Point') ||
+      frame?.includes('Start') ||
+      frame?.includes('O') ||
       false
   )
   unmount()


### PR DESCRIPTION
## Summary

Two logical groups of work.

### 1. Bug fixes (`f035c7d`)

Audit pass on the store and screen layer surfaced several real bugs:

- **NPC dialogue effects silently discarded.** `DialogueEngine.handleChoice` returned a new `GameState` but `NPCInteractionScreen` dropped it on the floor with a `// TODO`, so cash/reputation/inventory changes from dialogue were cosmetic only. New `applyDialogueChoice` store action encapsulates the dispatch.
- **NPCInteractionScreen reset loop.** The init effect was keyed on the full `gameState`, so any cash/day/inventory tick mid-conversation reset dialogue state and polluted conversation history. Scoped to `[npc.id]`; reads the snapshot via `useStore.getState()` at init.
- **`loadGame` left stale state.** Saves captured mid-travel or mid-combat left transient state behind. Now resets `travel`, `combat`, and the event queue as well as events/NPC.
- **`advanceDay` nested `set()` inside an Immer producer.** Calling `get().triggerEvent()` from within `set(...)` risked overwriting the outer draft. Follow-up action now runs after the `set()` commits.
- **`completeTravel` leaked `travel.phase = 'complete'`** forever. Resets to `'idle'` so subsequent `startTravel` calls aren't gated by a stale marker.
- **Cargo-cult `get().events.phase`** in `chooseEvent` along with its misleading "middleware timing" comment — removed; the call did nothing.
- **`repayDebt` didn't auto-save.** Now matches brew/sell/complete-travel.

### 2. Travel pipeline overhaul (`678a552`)

**Structural cleanup**
- `TravelAnimation` owns duration and fires `onComplete` when finished. The old split — `TravelingScreen` running a 4s countdown while `TravelAnimation` ran a 5.2s looping scene — meant the animation was always cut off early. Plays once now (`isLooping={false}`); explicit `durationMs` prop.
- `TravelingScreen` reads `travel.origin` and `travel.destination` directly from the store. Previous implementation passed `state.game.location.name` as `toLocation`, which is still the origin during the animating phase — so the destination label in the scene was silently wrong. **Hidden bug fixed.**
- `GameScreen` dropped the `previousLocation` state + `fromLocation` prop plumbing.
- Dropped the parallel flavor-text carousel; the scene's footer beats own the narration.
- Removed dead `getLocationSpecificAnimation` (hardcoded location names that never matched any real location in-game).
- Duration scales by `destination.dangerLevel`: Peasant Village ~2.8s, Alchemist's Quarter ~4.8s. Safety timeout at `duration + 2s` guards against stuck animations.

**Scene enhancements**
- **Weather overlays** — rainy (sparse slanted rain), stormy (dense rain + lightning flash every 6 frames + white sky flash), foggy (two-row mist band), windy (drifting streaks). Overlay preserves the traveler and road by filling only empty cells.
- **Biome silhouettes** per destination — castle crenellations, forest canopy, alchemist chimneys, merchant stalls, cottage peaks — rendered above the horizon once travel crosses 35%.
- **Danger accents** scale with level: `;` at 5–6, `░` at 7+, scattered on road-edge columns.
- **Time-of-day cycle** tied to `game.day % 4`: dawn (sun left-low, fading stars), day (arcing sun), dusk (sun right, rising moon), night (stars + moon). Narrative beats switch on weather.

**Color**
- `AsciiAnimation` gained an optional `colorByRow` prop. Non-coloring callers still use the single-`<Text>` fast path.
- Travel scenes pass a resolver that tints sky by time-of-day + weather (dawn=yellow, day=cyan, dusk=magenta, night=blueBright; stormy=gray with whiteBright flash; foggy=gray; rainy=blue), horizon green, road gray, footer yellow/cyan, biome row white/magenta/blueBright.

**Controls**
- **Space** pauses/resumes via imperative `AsciiAnimationControls` ref — animation holds its current frame instead of restarting from 0.
- **+/-** adjusts speed between 0.5× and 3.0× (step 0.25).
- Footer shows live status: `Enter skip · Space running · +/- speed ×1.25`.
- Safety timeout stretches with speed so slow/paused viewing doesn't force-complete.

## Test plan

- [x] `yarn build` — clean
- [x] Travel scene tests — 14 specs covering structural behavior (onComplete fires, duration scaling, destination label), weather rain density vs. sunny, fog band, danger-shadow density, biome presence/absence
- [x] Store tests — NPC dialogue apply, loadGame reset, travel phase idle
- [x] NPCInteractionScreen tests — no longer reinitialize on game-state ticks
- [x] Full suite: 616 pass. The single remaining failure (`tests/app.test.js` snapshot) pre-exists on unmodified `main` — unrelated.
- [ ] Manual smoke test the in-game travel flow on each weather × time-of-day combo
- [ ] `yarn anim:preview --from "Peasant Village" --to "Royal Castle"` to eyeball scene output

## Out of scope

- **Foreshadowing the actual post-travel outcome** (pre-rolling combat/NPC/event at `startTravel` time so the scene can hint at it). Foreshadowing in this PR is generic/danger-based; committing outcomes pre-travel is its own refactor.
- The pre-existing `tests/app.test.js` snapshot failure — stale before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)